### PR TITLE
Fix checksumming

### DIFF
--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1749,7 +1749,7 @@ class Transfers:
 
     def getChecksum(self, path):
         try:
-            h = open(path)
+            h = open(path, 'rb')
             m = hashlib.md5()
             m.update(h.read(-1))
             digest = m.digest()


### PR DESCRIPTION
Should be able to repro by restarting while a download is in progress.
Was getting "UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 37: invalid start byte"