### PR TITLE
Fix adding a downloaded file to shares.

### DIFF
--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -1055,7 +1055,8 @@ class Shares:
         sharedstreams = config["transfers"]["sharedfilesstreams"]
         wordindex = config["transfers"]["wordindex"]
         fileindex = config["transfers"]["fileindex"]
-        shareddirs = config["transfers"]["shared"] + [config["transfers"]["downloaddir"]]
+        shareddirs = [path for _name, path in config["transfers"]["shared"]]
+        sharedmtimes.append(config["transfers"]["downloaddir"])
         sharedmtimes = config["transfers"]["sharedmtimes"]
 
         dir = str(os.path.expanduser(os.path.dirname(name)))


### PR DESCRIPTION
config["transfers"]["shared"] is a list of (virtual path) tuples, see _convert_to_virtual in config.py. This looks like a pre-existing bug, sorry @kiplingw for opening it here but I have trouble running the python 2 one form source. It isn't fatal but causes the downloads panel to not get updated at least.

    Traceback (most recent call last):
      File "~/projects/nicotine-plus/pynicotine/gtkgui/frame.py", line 1383, in OnNetworkEvent
        self.np.events[i.__class__](i)
      File "~/projects/nicotine-plus/pynicotine/pynicotine.py", line 1673, in FileDownload
        self.transfers.FileDownload(msg)
      File "~/projects/nicotine-plus/pynicotine/transfers.py", line 1253, in FileDownload
        self.addToShared(newname)
      File "~/projects/nicotine-plus/pynicotine/transfers.py", line 1310, in addToShared
        self.eventprocessor.shares.addToShared(name)
      File "~/projects/nicotine-plus/pynicotine/shares.py", line 1076, in addToShared
        words = self.getIndexWords(dir, file, shareddirs)
      File "~/projects/nicotine-plus/pynicotine/shares.py", line 1035, in getIndexWords
        if os.path.commonprefix([dir, i]) == i:
      File "/usr/lib/python3.8/genericpath.py", line 77, in commonprefix
        m = tuple(map(os.fspath, m))
    TypeError: expected str, bytes or os.PathLike object, not tuple